### PR TITLE
fix: add minimum height of full screen to page divs

### DIFF
--- a/frontend/src/pages/JournalPage.jsx
+++ b/frontend/src/pages/JournalPage.jsx
@@ -3,7 +3,7 @@ import Navbar from '../components/generic/Navbar';
 
 const JournalPage = () => {
 	return (
-		<div>
+		<div className="min-h-screen">
 			<Navbar />
 			<h1>Journal Page</h1>
 		</div>

--- a/frontend/src/pages/MarketPage.jsx
+++ b/frontend/src/pages/MarketPage.jsx
@@ -3,7 +3,7 @@ import Navbar from '../components/generic/Navbar';
 
 const MarketPage = () => {
 	return (
-		<div>
+		<div className="min-h-screen">
 			<Navbar />
 			<h1>Market Page</h1>
 		</div>

--- a/frontend/src/pages/SettingsPage.jsx
+++ b/frontend/src/pages/SettingsPage.jsx
@@ -3,7 +3,7 @@ import Navbar from '../components/generic/Navbar';
 
 const SettingsPage = () => {
 	return (
-		<div>
+		<div className="min-h-screen">
 			<Navbar />
 			<h1>Settings Page</h1>
 		</div>

--- a/frontend/src/pages/SignInPage.jsx
+++ b/frontend/src/pages/SignInPage.jsx
@@ -3,7 +3,7 @@ import Navbar from '../components/generic/Navbar';
 
 const SignInPage = () => {
 	return (
-		<div>
+		<div className="min-h-screen">
 			<Navbar />
 			<h1>Sign-in Page</h1>
 		</div>


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and agree to adhere to the [Contribution Guidelines](https://github.com/freeCodeCamp-2025-Summer-Hackathon/purple-array/blob/main/contribution-guidelines.md).
- [x] My pull request targets the `main` branch of the repository.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #69 

<!-- Feel free to add any additional description of changes below this line -->
- added single `className=""` attribute to basic divs to have pages display has screen height