### PR TITLE
feat: add success/error messaging

### DIFF
--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -4,12 +4,50 @@ import './index.css';
 import App from './App.jsx';
 import { BrowserRouter } from 'react-router';
 import { Toaster } from 'react-hot-toast';
+import { MessageCircleHeart, CloudCheck, CloudAlert, Bubbles } from 'lucide-react';
 
 createRoot(document.getElementById('root')).render(
 	<StrictMode>
 		<BrowserRouter>
 			<App />
-			<Toaster />
+			<Toaster
+                position='top-center'
+                toastOptions={{
+                    duration: 4000,
+                    removeDelay: 500,
+                    style: {
+                        border: '1px solid #000000',
+                        background: '#1affff',
+                        color: '#3d4343'
+                    },
+                    icon: <MessageCircleHeart />,
+                    
+                    success: {
+                        style: {
+                            border: '1px solid #004d00',
+                            background: '#1aff1a',
+                            color: '#004d00',
+                        },
+                        icon: <CloudCheck />,
+                    },
+                    error: {
+                        style: {
+                            border: '1px solid #800000',
+                            background: '#e60000',
+                            color: '#fff'
+                        },
+                        icon: <CloudAlert />
+                    },
+                    loading: {
+                        style: {
+                            border: '1px solid #7a4f05',
+                            background: '#f59e0b',
+                            color: '#fff'
+                        },
+                        icon: <Bubbles />
+                    }
+                }}
+            />
 		</BrowserRouter>
 	</StrictMode>
 );


### PR DESCRIPTION
Add basic styling for success, error, and load message alerts. Relevant <Toaster /> in main.jsx

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and agree to adhere to the [Contribution Guidelines](https://github.com/freeCodeCamp-2025-Summer-Hackathon/purple-array/blob/main/contribution-guidelines.md).
- [x] My pull request targets the `main` branch of the repository.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #37

<!-- Feel free to add any additional description of changes below this line -->
