### PR TITLE
feat: add reusable JournalCard component and JournalEntriesList for /…

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -13,7 +13,8 @@
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "react-hot-toast": "^2.5.2",
-        "react-router": "^7.6.3"
+        "react-router": "^7.6.3",
+        "react-router-dom": "^7.6.3"
       },
       "devDependencies": {
         "@eslint/js": "^9.29.0",
@@ -3735,6 +3736,22 @@
         "react-dom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.6.3.tgz",
+      "integrity": "sha512-DiWJm9qdUAmiJrVWaeJdu4TKu13+iB/8IEi0EW/XgaHCjW/vWGrwzup0GVvaMteuZjKnh5bEvJP/K0MDnzawHw==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.6.3"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
       }
     },
     "node_modules/read-cache": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,7 +15,8 @@
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-hot-toast": "^2.5.2",
-    "react-router": "^7.6.3"
+    "react-router": "^7.6.3",
+    "react-router-dom": "^7.6.3"
   },
   "devDependencies": {
     "@eslint/js": "^9.29.0",

--- a/frontend/src/components/journal/JournalCard.jsx
+++ b/frontend/src/components/journal/JournalCard.jsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { CalendarFold } from "lucide-react";
+import { Link } from "react-router-dom";
+
+const JournalCard = ({ date, word }) => {
+  return (
+    <Link to={`${date}`} className="flex flex-1 basis-1/3 m-1 min-w-fit p-6 bg-base-100 rounded-md hover:bg-base-300 transition">
+      <div className="flex justify-between w-full">
+        <div className="flex gap-3 items-center">
+          <CalendarFold className="text-primary" strokeWidth={1} />
+          <span>{date}</span>
+        </div>
+        <div>{word || "Placeholder"}</div>
+      </div>
+    </Link>
+  );
+};
+
+export default JournalCard;

--- a/frontend/src/components/journal/JournalEntriesList.jsx
+++ b/frontend/src/components/journal/JournalEntriesList.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react"
 import { Loader, CalendarFold } from "lucide-react"
-import { Link, useParams } from "react-router"
+import { useParams } from "react-router-dom"
+import JournalCard from "./JournalCard"
 
 const JournalEntriesList = () => {
 
@@ -30,12 +31,7 @@ const JournalEntriesList = () => {
               {isLoading && <div className="flex gap-3"><Loader />Loading...</div>}
               {entries.map((entry)=>{
                 return (
-                  <Link to={`${entry.date}`} key={entry.date} className="flex flex-1 basis-1/3 m-1 min-w-fit p-6 bg-base-100 rounded-md"> 
-                    <div className="flex justify-between w-full">
-                      <div className="flex gap-3"><CalendarFold className="text-primary" strokeWidth={1}/> {entry.date}</div>
-                      <div>{entry.word}</div>                  
-                    </div>
-                  </Link>
+                  <JournalCard key={entry.date} date={entry.date} word={entry.word} />
                 )
               })}
             </div>


### PR DESCRIPTION
…journal/collection

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and agree to adhere to the [Contribution Guidelines](https://github.com/freeCodeCamp-2025-Summer-Hackathon/purple-array/blob/main/contribution-guidelines.md).
- [x] My pull request targets the `main` branch of the repository.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #126

<!-- Feel free to add any additional description of changes below this line -->

## Summary

- Created a reusable `JournalCard` component to display journal entries.
- Built `JournalEntriesList` to fetch and render multiple journal cards.
- Integrated this list into the `/journal/collection` route via `JournalCollectionPage`.
- Styling done with DaisyUI + TailwindCSS for consistency.

## Affected Routes
- `/journal/collection`: shows entry cards
- `/journal`: still shows single entry detail

## Related Issue
Closes #126
