### PR TITLE
refactor: break useWord hook into separate parts of the fetch, useCal…

### DIFF
--- a/frontend/src/components/Home/WordOfTheDay.jsx
+++ b/frontend/src/components/Home/WordOfTheDay.jsx
@@ -1,41 +1,33 @@
 import { useWord } from '../../util/hooks/useWord';
 
 function WordOfTheDay() {
-    const hookResult = useWord();
-    const wordData = hookResult.wordData;
-    const loading = hookResult.loading;
-
-
-	if (loading) {
-		return (
-			<div className="flex justify-center items-center h-64">
-				<div className="card w-full max-w-3xl bg-base-200 p-10 shadow-md animate-pulse">
-					<div className="h-6 bg-base-300 rounded w-1/3 mb-4"></div>
-					<div className="h-4 bg-base-300 rounded w-2/3 mb-2"></div>
-					<div className="h-4 bg-base-300 rounded w-full mb-1"></div>
-					<div className="h-4 bg-base-300 rounded w-5/6"></div>
-				</div>
-			</div>
-		);
-	}
+	const { word, isLoading } = useWord();
+	console.log(word);
 
 	return (
-		<div className="flex justify-center px-4 py-10">
-			<div className="card w-full max-w-3xl bg-base-200 shadow-xl border border-base-300 p-10 text-center space-y-6">
-				<h2 className="text-4xl font-bold text-primary">
-					{wordData.word}
-				</h2>
-				<p className="text-md text-neutral italic">
-					{wordData.pronunciation}
-				</p>
-				<p className="text-lg text-base-content/70 whitespace-pre-line">
-  Definition: <b>{wordData.definition}</b>
-</p>
+		<>
+			{isLoading && (
+				<div className="flex justify-center items-center h-64">
+					<div className="card w-full max-w-3xl bg-base-200 p-10 shadow-md animate-pulse">
+						<div className="h-6 bg-base-300 rounded w-1/3 mb-4"></div>
+						<div className="h-4 bg-base-300 rounded w-2/3 mb-2"></div>
+						<div className="h-4 bg-base-300 rounded w-full mb-1"></div>
+						<div className="h-4 bg-base-300 rounded w-5/6"></div>
+					</div>
+				</div>
+			)}
 
+			<div className="flex justify-center px-4 py-10">
+				<div className="card w-full max-w-3xl bg-base-200 shadow-xl border border-base-300 p-10 text-center space-y-6">
+					<h2 className="text-4xl font-bold text-primary">{'word'}</h2>
+					<p className="text-md text-neutral italic">{'pronunciation'}</p>
+					<p className="text-lg text-base-content/70 whitespace-pre-line">
+						Definition: <b>{'definition'}</b>
+					</p>
+				</div>
 			</div>
-		</div>
+		</>
 	);
 }
 
 export default WordOfTheDay;
-

--- a/frontend/src/util/api/word.js
+++ b/frontend/src/util/api/word.js
@@ -1,0 +1,14 @@
+import api from '../../lib/axios';
+
+export const fetchWord = async () => {
+	const url = `word`;
+	try {
+		const data = await api.get(url, {
+			withCredentials: true,
+		});
+
+		return data.data;
+	} catch (error) {
+		throw error;
+	}
+};

--- a/frontend/src/util/hooks/useWord.js
+++ b/frontend/src/util/hooks/useWord.js
@@ -1,41 +1,28 @@
-import { useState, useEffect } from 'react';
+import { useCallback, useEffect, useState } from 'react';
+import { fetchWord } from '../api/word';
 
 export const useWord = () => {
-	const [words, setWords] = useState([]);
-	const [loading, setLoading] = useState(true);
+	const [data, setData] = useState({});
+	const [isLoading, setIsLoading] = useState(false);
 
-	useEffect(() => {
-		fetch('/wordDict.json')
-			.then((res) => res.json())
-			.then((data) => {
-				setWords(data);
-				setLoading(false);
-			})
-			.catch((err) => {
-				console.error('Error loading JSON:', err);
-				setLoading(false);
-			});
+	const getWord = useCallback(async () => {
+		try {
+			setIsLoading(true);
+			const word = await fetchWord();
+			setData(word);
+		} catch (error) {
+			setData({});
+			throw error;
+		} finally {
+			setIsLoading(false);
+		}
 	}, []);
 
-	const getESTDate = () => {
-		const now = new Date();
-		const utc = now.getTime() + now.getTimezoneOffset() * 60000;
-		const estOffset = -5;
-		return new Date(utc + 3600000 * estOffset);
-	};
+	useEffect(() => {
+		getWord();
+	}, []);
 
-	let wordIdx = 0;
-	if (words.length > 0) {
-		const estDate = getESTDate();
-		const start = new Date('2025-07-01T00:00:00');
-		const daysSince = Math.floor((estDate - start) / (1000 * 60 * 60 * 24));
-		wordIdx = ((daysSince % 30) + 30) % 30;
-	}
-
-	const wordData = words[wordIdx];
-
-	return {
-		wordData,
-		loading,
-	};
+	return { word: data, isLoading };
 };
+
+export default useWord;


### PR DESCRIPTION
### PR sets up the refactored workflow for the useWord() Hook

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and agree to adhere to the [Contribution Guidelines](https://github.com/freeCodeCamp-2025-Summer-Hackathon/purple-array/blob/main/contribution-guidelines.md).
- [x] My pull request targets the `main` branch of the repository.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #174 

<!-- Feel free to add any additional description of changes below this line -->

- creates `frontend/src/util/api/word.js`
- updates `frontend/src/util/hook/useWord.js`
- imports `useWord()` into `<WordOfTheDay />` component
- sets up placeholders for data for now
- refactors conditional visibility of loading block to make use of a single return statement