### PR TITLE
style: Journal Entry Page unified to app theme

### DIFF
--- a/frontend/src/components/journal/JournalEntry.jsx
+++ b/frontend/src/components/journal/JournalEntry.jsx
@@ -2,6 +2,7 @@ import { Link } from "react-router";
 import { useState, useEffect } from "react";
 import { formatDate } from "../../util/helper/formatDate";
 import { useWord } from "../../util/hooks/useWord";
+import { Pencil, Plus } from "lucide-react";
 
 const JournalEntry = ({ date }) => {
   const [response, setResponse] = useState(null);
@@ -44,111 +45,139 @@ const JournalEntry = ({ date }) => {
   }
 
   return (
-    <div className="min-h-screen pt-8">
-      <header className="flex justify-between">
-        <h2 className="text-2xl font-semibold text-secondary">
-          {response?.word || currentWord}
-        </h2>
-        <span>{displayDate}</span>
-
-        {/*Ternary option for edit/create*/}
-        {response ? (
-          <Link to={"/edit"} className="btn btn-sm md:btn-md">
-            Edit
-          </Link>
-        ) : (
-          <Link to={"/create"} className="btn btn-sm md:btn-md">
-            Create
-          </Link>
-        )}
-      </header>
+    <div className="min-h-screen">
+      <header className="flex justify-center"></header>
       <br />
-      <div className="flex items-center justify-center p-4">
+      <div className="flex flex-col items-center justify-center p-4">
         {/*Podium Background*/}
-        <div
-          className="bg-cover bg-center rounded-2xl shadow-2xl p-8 min-w-full min-h-96"
-          style={{ backgroundImage: 'url("../../../assets/woodSurface.jpg")' }}
-        >
-          {/*Journal Container*/}
-          <div className="flex flex-col lg:flex-row gap-6 max-w-4xl drop-shadow-xl">
+        {/* <div
+        // className="bg-cover bg-center rounded-2xl shadow-2xl p-8 min-w-full min-h-96"
+        // style={{ backgroundImage: 'url("../../../assets/woodSurface.jpg")' }}
+        > */}
+        <div className="container">
+          <div className="card mx-auto max-w-3xl bg-base-200 p-6 shadow-md">
+            <div className="grid grid-cols-[auto_1fr_auto] items-center gap-2">
+              <div>
+                <h2 className="text-2xl font-semibold text-secondary">
+                  {response?.word || currentWord}
+                </h2>
+                {/*Ternary option for edit/create*/}
+                <span className="text-xl uppercase tracking-widest text-secondary font-semibold mt-0">
+                  {formatDate(new Date())}
+                </span>{" "}
+              </div>
+              <div></div>
+              <div>
+                {response ? (
+                  <Link
+                    to={"/edit"}
+                    className="btn btn-circle bg-neutral-300 btn-lg"
+                  >
+                    <Pencil />
+                  </Link>
+                ) : (
+                  <Link
+                    to={"/create"}
+                    className="btn btn-circle bg-neutral-300 btn-lg"
+                  >
+                    <Plus />
+                  </Link>
+                )}
+              </div>
+            </div>
+            {/*Journal Container*/}
+            {/* <div className="flex flex-col lg:flex-row gap-6 max-w-4xl drop-shadow-xl"> */}
             {/* Left Page */}
-            <div
-              className="bg-cover bg-center flex-1 shadow-lg p-6 space-y-6"
-              style={{
-                backgroundImage: 'url("../../../assets/parchmentPaper.png")',
-              }}
-            >
-              <div className="min-h-28 pb-5 m-3 space-y-2">
-                <h3 className="w-full text-lg font-semibold text-secondary">
-                  How did you use today's word?
+            {/* <div
+                className="bg-cover bg-center flex-1 p-6 space-y-6"
+                style={
+                  {
+                    // backgroundImage: 'url("../../../assets/parchmentPaper.png")',
+                  }
+                }
+              > */}
+            <hr className="my-6 border-t border-base-300" />
+            <div className="min-h-28 pb-5 m-3 space-y-2">
+              <h3 className="w-full text-lg font-semibold text-secondary">
+                How did you use today's word?
+              </h3>
+              {response?.response ? (
+                <p>{response.response}</p>
+              ) : (
+                <div className="min-h-24 w-full p-4"></div>
+              )}
+            </div>
+            <div className="min-h-28 pb-5 m-3 space-y-2">
+              {response?.optionalPrompt1 ? (
+                <h3 className="text-lg font-semibold text-secondary">
+                  {response.optionalPrompt1}
                 </h3>
-                {response?.response ? (
-                  <p>{response.response}</p>
-                ) : (
-                  <div className="min-h-24 w-full p-4"></div>
-                )}
-              </div>
-              <div className="min-h-28 m-3 space-y-2">
-                {response?.optionalPrompt1 ? (
-                  <h3 className="text-lg font-semibold text-secondary">
-                    {response.optionalPrompt1}
-                  </h3>
-                ) : (
-                  <h3 className="text-lg font-semibold text-secondary">
-                    Additional Prompt 1
-                  </h3>
-                )}
-                {response?.response1 ? (
-                  <p>{response.response1}</p>
-                ) : (
-                  <div className="min-h-24 w-full p-4"></div>
-                )}
-              </div>
+              ) : (
+                <h3 className="text-lg font-semibold text-secondary">
+                  Additional Prompt 1
+                </h3>
+              )}
+              {response?.response1 ? (
+                <p>{response.response1}</p>
+              ) : (
+                <div className="min-h-24 w-full p-4"></div>
+              )}
             </div>
-
             {/* Right Page */}
-            <div
-              className="bg-cover bg-center flex-1 shadow-lg p-6 space-y-6"
-              style={{
-                backgroundImage: 'url("../../../assets/parchmentPaper.png")',
-              }}
-            >
-              <div className="min-h-28 pb-5 m-3 space-y-2">
-                {response?.optionalPrompt2 ? (
-                  <h3 className="text-lg font-semibold text-secondary">
-                    {response.optionalPrompt2}
-                  </h3>
-                ) : (
-                  <h3 className="text-lg font-semibold text-secondary">
-                    Additional Prompt 2
-                  </h3>
-                )}
-                {response?.response2 ? (
-                  <p>{response.response2}</p>
-                ) : (
-                  <div className="min-h-24 w-full p-4"></div>
-                )}
-              </div>
-              <div className="min-h-28 pb-5 m-3 space-y-2">
-                {response?.optionalPrompt3 ? (
-                  <h3 className="text-lg font-semibold text-secondary">
-                    {response.optionalPrompt3}
-                  </h3>
-                ) : (
-                  <h3 className="text-lg font-semibold text-secondary">
-                    Additional Prompt 3
-                  </h3>
-                )}
-                {response?.response3 ? (
-                  <p>{response.response3}</p>
-                ) : (
-                  <div className="min-h-24 w-full p-4"></div>
-                )}
-              </div>
+            {/* <div
+                className="bg-cover bg-center flex-1 p-6 space-y-6"
+                // style={{
+                //   backgroundImage: 'url("../../../assets/parchmentPaper.png")',
+                // }}
+              > */}
+            <div className="min-h-28 pb-5 m-3 space-y-2">
+              {response?.optionalPrompt2 ? (
+                <h3 className="text-lg font-semibold text-secondary">
+                  {response.optionalPrompt2}
+                </h3>
+              ) : (
+                <h3 className="text-lg font-semibold text-secondary">
+                  Additional Prompt 2
+                </h3>
+              )}
+              {response?.response2 ? (
+                <p>{response.response2}</p>
+              ) : (
+                <div className="min-h-24 w-full p-4"></div>
+              )}
             </div>
+            <div className="min-h-28 pb-5 m-3 space-y-2">
+              {response?.optionalPrompt3 ? (
+                <h3 className="text-lg font-semibold text-secondary">
+                  {response.optionalPrompt3}
+                </h3>
+              ) : (
+                <h3 className="text-lg font-semibold text-secondary">
+                  Additional Prompt 3
+                </h3>
+              )}
+              {response?.response3 ? (
+                <p>{response.response3}</p>
+              ) : (
+                <div className="min-h-24 w-full p-4"></div>
+              )}
+            </div>{" "}
           </div>
+          {/* </div> */}
+          {/* </div> */}
+          {/* </div> */}
         </div>
+        <div className="w-full max-w-3xl mt-4 flex justify-center">
+          <Link
+            to={"/journal/collection"}
+            className="btn btn rounded-full bg-neutral-200 btn-lg mt-2"
+          >
+            Past Journal Entries
+          </Link>
+        </div>
+        {/* </div> */}
       </div>
+
       {/* {response && (
 				<footer className="text-end">
 					<Link to={'/'} className="btn btn-sm md:btn-md">


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and agree to adhere to the [Contribution Guidelines](https://github.com/freeCodeCamp-2025-Summer-Hackathon/purple-array/blob/main/contribution-guidelines.md).
- [x] My pull request targets the `main` branch of the repository.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #166 #107

<!-- Feel free to add any additional description of changes below this line -->

Journal page is now unified with app theme. Podium and paper that Dustin had there will be used as customization items for the demo user.
 - Path to populate the word of the day and entries will need to be refactored. 
 - I didn't add any color because font colors will be customization items.

<img width="1423" height="740" alt="image" src="https://github.com/user-attachments/assets/3d1dddb0-f263-4991-8bf5-39255c9e4547" />

---

Added button that successfully links to past entries page

<img width="1093" height="350" alt="image" src="https://github.com/user-attachments/assets/49436374-ca2a-4dbe-93cf-0a144cc61cfb" />

