### PR TITLE
Feat/connect past entries to journal entry page

### DIFF
--- a/frontend/src/components/journal/CollectionListCard.jsx
+++ b/frontend/src/components/journal/CollectionListCard.jsx
@@ -5,7 +5,7 @@ const CollectionListCard = (props) => {
 	return (
 		<Link
 			to={props.to}
-			className="flex flex-1 basis-1/3 m-1 min-w-fit p-6 bg-base-100 rounded-md opacity-85 hover:scale-[1.02] hover:opacity-100 transition-all ease-in-out duration-300"
+			className="flex flex-1 basis-1/3 m-1 min-w-fit p-6 bg-base-100 rounded-md opacity-80 hover:scale-[1.03] hover:opacity-100 transition-all ease-in-out duration-500"
 		>
 			<div className="flex justify-between w-full">
 				<div className="flex gap-3">

--- a/frontend/src/components/journal/CollectionListCard.jsx
+++ b/frontend/src/components/journal/CollectionListCard.jsx
@@ -5,7 +5,7 @@ const CollectionListCard = (props) => {
 	return (
 		<Link
 			to={props.to}
-			className="flex flex-1 basis-1/3 m-1 min-w-fit p-6 bg-base-100 rounded-md opacity-80 hover:scale-[1.02] hover:opacity-100 transition-all ease-in-out duration-300"
+			className="flex flex-1 basis-1/3 m-1 min-w-fit p-6 bg-base-100 rounded-md opacity-85 hover:scale-[1.02] hover:opacity-100 transition-all ease-in-out duration-300"
 		>
 			<div className="flex justify-between w-full">
 				<div className="flex gap-3">

--- a/frontend/src/components/journal/CollectionListCard.jsx
+++ b/frontend/src/components/journal/CollectionListCard.jsx
@@ -5,7 +5,7 @@ const CollectionListCard = (props) => {
 	return (
 		<Link
 			to={props.to}
-			className="flex flex-1 basis-1/3 m-1 min-w-fit p-6 bg-base-100 rounded-md"
+			className="flex flex-1 basis-1/3 m-1 min-w-fit p-6 bg-base-100 rounded-md opacity-80 hover:scale-[1.02] hover:opacity-100 transition-all ease-in-out duration-300"
 		>
 			<div className="flex justify-between w-full">
 				<div className="flex gap-3">

--- a/frontend/src/components/journal/JournalEntriesList.jsx
+++ b/frontend/src/components/journal/JournalEntriesList.jsx
@@ -1,5 +1,5 @@
-import { Loader } from 'lucide-react';
 import useEntries from '../../util/hooks/useEntries';
+import { Loader } from 'lucide-react';
 import CollectionListCard from './CollectionListCard';
 import EntriesNotFound from './EntriesNotFound';
 

--- a/frontend/src/components/journal/JournalEntry.jsx
+++ b/frontend/src/components/journal/JournalEntry.jsx
@@ -48,7 +48,7 @@ const JournalEntry = ({ entry_id, entryDate, pastEntry }) => {
 			{/* *********************** Animated Loader *********************** */}
 			{isLoading && <AnimatePulseLoader />}
 
-			<div className="max-w-3xl mx-auto mt-12 px-6">
+			<div className="max-w-3xl mx-auto mt-12 px-6 pb-6">
 				{/* *********************** Footer Button Wrapper Header *********************** */}
 				<div className="flex justify-between mb-6 items-center">
 					<div className="text-2xl font-semibold text-slate-700 ml-10">

--- a/frontend/src/components/journal/JournalEntry.jsx
+++ b/frontend/src/components/journal/JournalEntry.jsx
@@ -27,65 +27,42 @@ const JournalEntry = ({ entry_id, entryDate, pastEntry }) => {
 			return formatDate(new Date(entry.date + 'T00:00:00')) === todayDate;
 		});
 
-		// check whether this is the journal page or a page entry
-		if (!entry_id) {
-			setCurrentEntry(initialData);
-			// } else if (todayEntry) {
-			// 	setCurrentEntry(todayEntry);
+		const dateEntry = entries.find((entry) => {
+			return formatDate(new Date(entry.date + 'T00:00:00')) === entryDate;
+		});
+
+		if (entry_id) {
+			// if page is a past entry
+			setCurrentEntry(dateEntry);
+		} else if (!entry_id || todayDate) {
+			// not on journal page (no entry-id), but there is a today entry
+			setCurrentEntry(todayEntry);
 		} else {
-			setCurrentEntry(
-				entries.find((entry) => {
-					return formatDate(new Date(entry.date + 'T00:00:00')) === entryDate;
-				})
-			);
+			// not on journal page and no today entry
+			setCurrentEntry(initialData);
 		}
 	}, [entries]);
-
-	const [response, setResponse] = useState(null);
-
-	// if (entry_id) {
-	// 	setCurrentEntry(
-	// 		entries.find((entry) => {
-	// 			return formatDate(new Date(entry.date + 'T00:00:00')) === todayDate;
-	// 		})
-	// 	);
-	// }
-
-	// if (!entry_id && !todayEntry) {
-	// 	setCurrentEntry(initialData);
-	// }
-
-	// journal page - can only be today or empty
-
-	// collection page can only be past entry
-
-	// useEffect(() => {
-	// 	const currentDate = formatDate(new Date());
-	// 	const targetDate = date || currentDate;
-	// 	fetch('/placeholderJournalEntries.json')
-	// 		.then((res) => res.json())
-	// 		.then((data) => {
-	// 			const targetEntry = data.find((entry) => {
-	// 				const entryDate = formatDate(new Date(entry.date + 'T00:00:00'));
-	// 				return entryDate === targetDate;
-	// 			});
-	// 			setResponse(targetEntry || null);
-	// 			// setLoading(false);
-	// 		})
-	// 		.catch((err) => {
-	// 			console.error('Error loading response:', err);
-	// 			// setLoading(false);
-	// 		});
-	// }, []);
 
 	return (
 		<div className="min-h-screen">
 			{/* *********************** Animated Loader *********************** */}
 			{isLoading && <AnimatePulseLoader />}
 
-			<div className="max-w-3xl mx-auto">
+			<div className="max-w-3xl mx-auto mt-12 px-6">
+				{/* *********************** Footer Button Wrapper Header *********************** */}
+				<div className="flex justify-between mb-6 items-center">
+					<div className="text-2xl font-semibold text-slate-700 ml-10">
+						{!entryDate && `Today's Entry`}
+					</div>
+					<Link
+						to={'/journal/collection'}
+						className="btn btn-outline btn-primary rounded-lg btn-lg"
+					>
+						Past Journal Entries
+					</Link>
+				</div>
 				{/* *********************** Journal Entry wrapper *********************** */}
-				<div className="card container mt-12 p-6 bg-base-200">
+				<div className="card container px-6 py-8 bg-base-200">
 					{/* *********************** Journal Entry Header *********************** */}
 					<div className="flex justify-between px-6">
 						<div className="card-title flex-col items-start">
@@ -115,7 +92,7 @@ const JournalEntry = ({ entry_id, entryDate, pastEntry }) => {
 								How did you use today's word?
 							</h3>
 
-							<div className="p-3 min-h-[10rem] border rounded-md border-base-content/20">
+							<div className="p-3 min-h-[10rem] bg-base-100 border rounded-md border-base-content/20">
 								{currentEntry?.response || ''}
 							</div>
 						</div>
@@ -126,7 +103,7 @@ const JournalEntry = ({ entry_id, entryDate, pastEntry }) => {
 								{currentEntry?.optionalPrompt1 ||
 									"What's something that you learned today?"}
 							</h3>
-							<div className="p-3 min-h-[10rem] border rounded-md border-base-content/20">
+							<div className="p-3 min-h-[10rem] bg-base-100 border rounded-md border-base-content/20">
 								{currentEntry?.response1 || ''}
 							</div>
 						</div>
@@ -136,7 +113,7 @@ const JournalEntry = ({ entry_id, entryDate, pastEntry }) => {
 							<h3 className="mb-4 w-full text-lg font-semibold text-secondary">
 								{currentEntry?.optionalPrompt2 || 'What gave you hope today?'}
 							</h3>
-							<div className="p-3 min-h-[10rem] border rounded-md border-base-content/20">
+							<div className="p-3 min-h-[10rem] bg-base-100 border rounded-md border-base-content/20">
 								{currentEntry?.response2 || ''}
 							</div>
 						</div>
@@ -147,20 +124,11 @@ const JournalEntry = ({ entry_id, entryDate, pastEntry }) => {
 								{currentEntry?.optionalPrompt3 ||
 									'How did you show kindness today?'}
 							</h3>
-							<div className="p-3 min-h-[10rem] border rounded-md border-base-content/20">
+							<div className="p-3 min-h-[10rem] bg-base-100 border rounded-md border-base-content/20">
 								{currentEntry?.response3 || ''}
 							</div>
 						</div>
 					</div>
-				</div>
-				{/* *********************** Footer Button Wrapper Header *********************** */}
-				<div className="flex justify-start my-6">
-					<Link
-						to={'/journal/collection'}
-						className="btn btn-outline btn-primary rounded-lg btn-lg"
-					>
-						Past Journal Entries
-					</Link>
 				</div>
 			</div>
 		</div>

--- a/frontend/src/components/journal/JournalEntry.jsx
+++ b/frontend/src/components/journal/JournalEntry.jsx
@@ -1,180 +1,168 @@
 import { Link } from 'react-router';
 import { useState, useEffect } from 'react';
 import { formatDate } from '../../util/helper/formatDate';
-import { useWord } from '../../util/hooks/useWord';
-import { Pencil, Plus } from 'lucide-react';
+import useWord from '../../util/hooks/useWord';
+import useEntries from '../../util/hooks/useEntries';
+import { CloudUpload, Pencil, Plus } from 'lucide-react';
 import AnimatePulseLoader from '../generic/AnimatePulseLoader';
 
-const JournalEntry = ({ date }) => {
+const JournalEntry = ({ entry_id, entryDate, pastEntry }) => {
 	const { word, isLoading } = useWord();
+	const { entries } = useEntries();
+	const [currentEntry, setCurrentEntry] = useState({});
+	const todayDate = formatDate(new Date());
+	const initialData = {
+		optionalPrompt1: '',
+		optionalPrompt2: '',
+		optionalPrompt3: '',
+		response: '',
+		response1: '',
+		response2: '',
+		response3: '',
+	};
 
-	// const [loading, setLoading] = useState(true);
-	// const displayDate = formatDate(new Date());
+	// Determine which entry to load
+	useEffect(() => {
+		const todayEntry = entries.find((entry) => {
+			return formatDate(new Date(entry.date + 'T00:00:00')) === todayDate;
+		});
+
+		// check whether this is the journal page or a page entry
+		if (!entry_id) {
+			setCurrentEntry(initialData);
+			// } else if (todayEntry) {
+			// 	setCurrentEntry(todayEntry);
+		} else {
+			setCurrentEntry(
+				entries.find((entry) => {
+					return formatDate(new Date(entry.date + 'T00:00:00')) === entryDate;
+				})
+			);
+		}
+	}, [entries]);
 
 	const [response, setResponse] = useState(null);
 
-	useEffect(() => {
-		const currentDate = formatDate(new Date());
-		const targetDate = date || currentDate;
-		fetch('/placeholderJournalEntries.json')
-			.then((res) => res.json())
-			.then((data) => {
-				const targetEntry = data.find((entry) => {
-					const entryDate = formatDate(new Date(entry.date + 'T00:00:00'));
-					return entryDate === targetDate;
-				});
-				setResponse(targetEntry || null);
-				// setLoading(false);
-			})
-			.catch((err) => {
-				console.error('Error loading response:', err);
-				// setLoading(false);
-			});
-	}, []);
+	// if (entry_id) {
+	// 	setCurrentEntry(
+	// 		entries.find((entry) => {
+	// 			return formatDate(new Date(entry.date + 'T00:00:00')) === todayDate;
+	// 		})
+	// 	);
+	// }
+
+	// if (!entry_id && !todayEntry) {
+	// 	setCurrentEntry(initialData);
+	// }
+
+	// journal page - can only be today or empty
+
+	// collection page can only be past entry
+
+	// useEffect(() => {
+	// 	const currentDate = formatDate(new Date());
+	// 	const targetDate = date || currentDate;
+	// 	fetch('/placeholderJournalEntries.json')
+	// 		.then((res) => res.json())
+	// 		.then((data) => {
+	// 			const targetEntry = data.find((entry) => {
+	// 				const entryDate = formatDate(new Date(entry.date + 'T00:00:00'));
+	// 				return entryDate === targetDate;
+	// 			});
+	// 			setResponse(targetEntry || null);
+	// 			// setLoading(false);
+	// 		})
+	// 		.catch((err) => {
+	// 			console.error('Error loading response:', err);
+	// 			// setLoading(false);
+	// 		});
+	// }, []);
 
 	return (
 		<div className="min-h-screen">
+			{/* *********************** Animated Loader *********************** */}
 			{isLoading && <AnimatePulseLoader />}
 
-			<div className="flex flex-col items-center justify-center p-10">
-				<header className="flex justify-center"></header>
-				<div className="flex flex-col items-center justify-center p-4">
-					{/*Podium Background*/}
-					{/* <div
-        // className="bg-cover bg-center rounded-2xl shadow-2xl p-8 min-w-full min-h-96"
-        // style={{ backgroundImage: 'url("../../../assets/woodSurface.jpg")' }}
-        > */}
-					<div className="container">
-						<div className="card mx-auto max-w-3xl bg-base-200 p-6 shadow-md">
-							<div className="grid grid-cols-[auto_1fr_auto] items-center gap-2">
-								<div>
-									<h2 className="mb-2 text-2xl font-semibold text-primary">
-										{word.word}
-									</h2>
-									{/*Ternary option for edit/create*/}
-									<span className="text-xl uppercase tracking-widest text-secondary font-semibold mt-0">
-										{formatDate(new Date())}
-									</span>
-								</div>
-								<div></div>
-								<div>
-									{response ? (
-										<Link
-											to={'/edit'}
-											className="btn btn-circle bg-neutral-300 btn-lg"
-										>
-											<Pencil />
-										</Link>
-									) : (
-										<Link
-											to={'/create'}
-											className="btn btn-circle bg-neutral-300 btn-lg"
-										>
-											<Plus />
-										</Link>
-									)}
-								</div>
-							</div>
-							{/*Journal Container*/}
-							{/* <div className="flex flex-col lg:flex-row gap-6 max-w-4xl drop-shadow-xl"> */}
-							{/* Left Page */}
-							{/* <div
-                className="bg-cover bg-center flex-1 p-6 space-y-6"
-                style={
-                  {
-                    // backgroundImage: 'url("../../../assets/parchmentPaper.png")',
-                  }
-                }
-              > */}
-							<hr className="my-6 border-t border-base-300" />
-							<div className="min-h-28 pb-5 m-3 space-y-2">
-								<h3 className="w-full text-lg font-semibold text-secondary">
-									How did you use today's word?
-								</h3>
-								{response?.response ? (
-									<p>{response.response}</p>
-								) : (
-									<div className="min-h-24 w-full p-4"></div>
-								)}
-							</div>
-							<div className="min-h-28 pb-5 m-3 space-y-2">
-								{response?.optionalPrompt1 ? (
-									<h3 className="text-lg font-semibold text-secondary">
-										{response.optionalPrompt1}
-									</h3>
-								) : (
-									<h3 className="text-lg font-semibold text-secondary">
-										Additional Prompt 1
-									</h3>
-								)}
-								{response?.response1 ? (
-									<p>{response.response1}</p>
-								) : (
-									<div className="min-h-24 w-full p-4"></div>
-								)}
-							</div>
-							{/* Right Page */}
-							{/* <div
-                className="bg-cover bg-center flex-1 p-6 space-y-6"
-                // style={{
-                //   backgroundImage: 'url("../../../assets/parchmentPaper.png")',
-                // }}
-              > */}
-							<div className="min-h-28 pb-5 m-3 space-y-2">
-								{response?.optionalPrompt2 ? (
-									<h3 className="text-lg font-semibold text-secondary">
-										{response.optionalPrompt2}
-									</h3>
-								) : (
-									<h3 className="text-lg font-semibold text-secondary">
-										Additional Prompt 2
-									</h3>
-								)}
-								{response?.response2 ? (
-									<p>{response.response2}</p>
-								) : (
-									<div className="min-h-24 w-full p-4"></div>
-								)}
-							</div>
-							<div className="min-h-28 pb-5 m-3 space-y-2">
-								{response?.optionalPrompt3 ? (
-									<h3 className="text-lg font-semibold text-secondary">
-										{response.optionalPrompt3}
-									</h3>
-								) : (
-									<h3 className="text-lg font-semibold text-secondary">
-										Additional Prompt 3
-									</h3>
-								)}
-								{response?.response3 ? (
-									<p>{response.response3}</p>
-								) : (
-									<div className="min-h-24 w-full p-4"></div>
-								)}
+			<div className="max-w-3xl mx-auto">
+				{/* *********************** Journal Entry wrapper *********************** */}
+				<div className="card container mt-12 p-6 bg-base-200">
+					{/* *********************** Journal Entry Header *********************** */}
+					<div className="flex justify-between px-6">
+						<div className="card-title flex-col items-start">
+							<h2 className=" text-2xl font-semibold text-primary w-full">
+								{currentEntry?.word || word.word}
+							</h2>
+							<span className="text-xl uppercase tracking-widest text-secondary font-semibold">
+								{!pastEntry ? todayDate : entryDate}
+							</span>
+						</div>
+
+						<div>
+							<Link
+								to={'/edit'}
+								className="btn btn-circle bg-neutral-300 btn-lg"
+							>
+								<Pencil />
+							</Link>
+						</div>
+					</div>
+
+					{/* *********************** Journal Entry Body *********************** */}
+					<div className="card border-base-content/20 p-2 mt-6">
+						{/* ******************** Question/Response 1 ******************** */}
+						<div className="p-4">
+							<h3 className="mb-4 w-full text-lg font-semibold text-secondary">
+								How did you use today's word?
+							</h3>
+
+							<div className="p-3 min-h-[10rem] border rounded-md border-base-content/20">
+								{currentEntry?.response || ''}
 							</div>
 						</div>
-						{/* </div> */}
-						{/* </div> */}
-						{/* </div> */}
-					</div>
-					<div className="w-full max-w-3xl mt-4 flex justify-center">
-						<Link
-							to={'/journal/collection'}
-							className="btn rounded-full bg-neutral-200 btn-lg mt-2"
-						>
-							Past Journal Entries
-						</Link>
+
+						{/* ******************** Question/Response 2 ******************** */}
+						<div className="p-4">
+							<h3 className="mb-4 w-full text-lg font-semibold text-secondary">
+								{currentEntry?.optionalPrompt1 ||
+									"What's something that you learned today?"}
+							</h3>
+							<div className="p-3 min-h-[10rem] border rounded-md border-base-content/20">
+								{currentEntry?.response1 || ''}
+							</div>
+						</div>
+
+						{/* ******************** Question/Response 3 ******************** */}
+						<div className="p-4">
+							<h3 className="mb-4 w-full text-lg font-semibold text-secondary">
+								{currentEntry?.optionalPrompt2 || 'What gave you hope today?'}
+							</h3>
+							<div className="p-3 min-h-[10rem] border rounded-md border-base-content/20">
+								{currentEntry?.response2 || ''}
+							</div>
+						</div>
+
+						{/* ******************** Question/Response 4 ******************** */}
+						<div className="p-4">
+							<h3 className="mb-4 w-full text-lg font-semibold text-secondary">
+								{currentEntry?.optionalPrompt3 ||
+									'How did you show kindness today?'}
+							</h3>
+							<div className="p-3 min-h-[10rem] border rounded-md border-base-content/20">
+								{currentEntry?.response3 || ''}
+							</div>
+						</div>
 					</div>
 				</div>
-			</div>
-
-			{/* {response && (
-				<footer className="text-end">
-					<Link to={'/'} className="btn btn-sm md:btn-md">
-						Delete
+				{/* *********************** Footer Button Wrapper Header *********************** */}
+				<div className="flex justify-start my-6">
+					<Link
+						to={'/journal/collection'}
+						className="btn btn-outline btn-primary rounded-lg btn-lg"
+					>
+						Past Journal Entries
 					</Link>
-				</footer>
-			)} */}
+				</div>
+			</div>
 		</div>
 	);
 };

--- a/frontend/src/components/journal/JournalEntry.jsx
+++ b/frontend/src/components/journal/JournalEntry.jsx
@@ -48,7 +48,7 @@ const JournalEntry = ({ entry_id, entryDate, pastEntry }) => {
 			{/* *********************** Animated Loader *********************** */}
 			{isLoading && <AnimatePulseLoader />}
 
-			<div className="max-w-3xl mx-auto mt-12 px-6 pb-6">
+			<div className="max-w-3xl mx-auto mt-12 px-6 pb-12">
 				{/* *********************** Footer Button Wrapper Header *********************** */}
 				<div className="flex justify-between mb-6 items-center">
 					<div className="text-2xl font-semibold text-slate-700 ml-10">

--- a/frontend/src/components/journal/JournalEntryForm.jsx
+++ b/frontend/src/components/journal/JournalEntryForm.jsx
@@ -4,15 +4,8 @@ import { formatDate } from '../../util/helper/formatDate';
 import { useWord } from '../../util/hooks/useWord';
 import { Trash2, CircleDollarSign } from 'lucide-react';
 
-const JournalEntryForm = (
-	{
-		//   initialData = {},
-		//   onSubmit = () => {},
-		//   onDelete = null,
-	}
-) => {
-	const { wordData, loading } = useWord();
-	const wordOfTheDay = wordData?.word || 'your word';
+const JournalEntryForm = () => {
+	const { word, isLoading } = useWord();
 
 	const [primaryPrompt, setPrimaryPrompt] = useState('');
 	const [addPromptOne, setAddPromptOne] = useState('');
@@ -50,7 +43,7 @@ const JournalEntryForm = (
 		// });
 	};
 
-	if (loading) {
+	if (isLoading) {
 		return (
 			<div className="flex justify-center items-center min-h-screen">
 				<span className="loading loading-spinner loading-lg text-primary"></span>
@@ -75,7 +68,7 @@ const JournalEntryForm = (
 						<label className="label font-semibold">
 							<h2 className="mt-4 text-lg font-semibold">
 								How did you use the word{' '}
-								<span className="text-primary font-bold">{wordOfTheDay}</span>{' '}
+								<span className="text-primary font-bold">{word.word}</span>{' '}
 								{/* *********************************************************************** */}
 								today?
 							</h2>
@@ -93,7 +86,7 @@ const JournalEntryForm = (
 							className="textarea textarea-bordered mt-2"
 							rows={4}
 							//   *************************************************************************
-							placeholder={`Write about how you used ${wordOfTheDay} today...`}
+							placeholder={`Write about how you used ${word.word} today...`}
 						/>
 					</div>
 
@@ -184,7 +177,6 @@ const JournalEntryForm = (
 						/>
 					</div>
 					<div className="flex justify-between items-center mt-6">
-
 						<Link
 							to="/journal"
 							className="text-lg font-semibold btn-u text-primary hover:underline"

--- a/frontend/src/pages/JournalEntryPage.jsx
+++ b/frontend/src/pages/JournalEntryPage.jsx
@@ -1,9 +1,20 @@
-import React from 'react'
+import { useParams } from 'react-router';
+import { formatDate } from '../util/helper/formatDate';
+import Navbar from '../components/generic/Navbar';
+import JournalEntry from '../components/journal/JournalEntry';
 
 const JournalEntryPage = () => {
-  return (
-    <div>JournalEntryPage</div>
-  )
-}
+	const { id } = useParams();
+	const todayDate = formatDate(new Date());
+	const entryDate = formatDate(new Date(id + 'T00:00:00'));
+	const pastEntry = todayDate !== entryDate;
 
-export default JournalEntryPage
+	return (
+		<>
+			<Navbar />
+			<JournalEntry entry_id={id} entryDate={entryDate} pastEntry={pastEntry} />
+		</>
+	);
+};
+
+export default JournalEntryPage;

--- a/frontend/src/pages/JournalEntryPage.jsx
+++ b/frontend/src/pages/JournalEntryPage.jsx
@@ -10,10 +10,10 @@ const JournalEntryPage = () => {
 	const pastEntry = todayDate !== entryDate;
 
 	return (
-		<>
+		<div className="min-h-screen">
 			<Navbar />
 			<JournalEntry entry_id={id} entryDate={entryDate} pastEntry={pastEntry} />
-		</>
+		</div>
 	);
 };
 

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -17,6 +17,14 @@ export default {
 		themes: [
 			'cupcake',
 			'wireframe',
+			'valentine',
+			'garden',
+			'pastel',
+			'dracula',
+			'night',
+			'coffee',
+			'winter',
+			'sunset',
 			{
 				writeLight: {
 					primary: '#463aa2',


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and agree to adhere to the [Contribution Guidelines](https://github.com/freeCodeCamp-2025-Summer-Hackathon/purple-array/blob/main/contribution-guidelines.md).
- [x] My pull request targets the `main` branch of the repository.
- [x] I have tested these changes either locally on my machine, or Gitpod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #111 

<!-- Feel free to add any additional description of changes below this line -->
- refactors the journal entry component to make use of dynamic data, 
- filters through journal entries coming in from BE to check if there is a current entry or not and display blank journal page when appropriate
- builds out the journal collection pages, and connects the journal entries to display the correct past entry
- fixes the word of the day variable on the journal entry form
- add hover style to collection list card component
- adds some additional theme options


https://github.com/user-attachments/assets/ed2586ef-34e7-407a-8ce3-4a94769c8f57

